### PR TITLE
add /health healthcheck endpoint

### DIFF
--- a/app/controllers/health_check_controller.rb
+++ b/app/controllers/health_check_controller.rb
@@ -1,0 +1,18 @@
+# Provides a healthcheck endpoint
+class HealthCheckController < ApplicationController
+  def health
+    if db_ready?
+      head :ok
+    else
+      head :service_unavailable
+    end
+  end
+
+  private
+
+  def db_ready?
+    !ApplicationRecord.connection.migration_context.needs_migration?
+  rescue ActiveRecord::ActiveRecordError
+    false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,5 +10,7 @@ Rails.application.routes.draw do
     post '/pseudonymise', to: 'pseudonymisation#pseudonymise'
   end
 
+  get '/health', to: 'health_check#health'
+
   root 'application#info'
 end

--- a/test/controllers/health_check_controller_test.rb
+++ b/test/controllers/health_check_controller_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class HealthCheckControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+  test 'healthy response' do
+    get '/health'
+    assert_response :ok
+  end
+
+  test 'with DB connectivity issue' do
+    ApplicationRecord.stubs(:connection).raises(ActiveRecord::ActiveRecordError)
+    get '/health'
+    assert_response :service_unavailable
+  end
+
+  test 'with pending migrations' do
+    ActiveRecord::MigrationContext.any_instance.stubs(needs_migration?: true)
+    get '/health'
+    assert_response :service_unavailable
+  end
+end


### PR DESCRIPTION
For a supervisor to poll.

Returns `200 OK` if ready to serve traffic and a `503` if the DB is not available, or not migrated.